### PR TITLE
bugfix

### DIFF
--- a/src/summery_VScode/content.js
+++ b/src/summery_VScode/content.js
@@ -31,7 +31,9 @@ chrome.storage.sync.get("UID", function(result){
 var paragraphs = $('body p');
 
 for(Element of paragraphs){
-    if(Element.textContent.trim() !== ""){
+    // show summarize button only if there are more than 3 sentences in a paragraph
+    if(Element.textContent.trim() !== "" && Element.textContent.split('.').length>3){
+        console.log(Element.textContent.split('.').length);
         console.log(Element.className += 'summarize_me');
     }
 }


### PR DESCRIPTION
button to summarize will be shown only if there are more than 3 sentences. This prevents a bug when summarizing short sentences or sentences with only short words.